### PR TITLE
added license header to entry point js program

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1,4 +1,23 @@
 /**
+ *  EFF Alerts is a pager style app that sends notifications to users
+ *  Copyright (C) 2014, 2015 Electronic Frontier Foundation
+ * 
+ *  This program is free software: you can redistribute it and/or
+ *  modify it under the terms of the GNU Affero General Public License
+ *  as published by the Free Software Foundation, either version 3 of
+ *  the License, or (at your option) any later version.
+ * 
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Affero General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Affero General Public
+ *  License along with this program.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ */
+
+/**
  * Primary application target, defines top level module and imports required files.
  */
 


### PR DESCRIPTION
I added a copyright, warrenty disclaimer, and license notice to what I believe is the "main" entry point of the program. I am assuming the intended license is GNU AGPLv3 or (at your option) any later version. I am assuming the copyright holder is EFF and that the dates are last year and this year. 