### PR TITLE
act.eff.org atom feed updates

### DIFF
--- a/www/js/controllers/action.js
+++ b/www/js/controllers/action.js
@@ -16,6 +16,7 @@ var ActionCtrl = function ($scope, $http, x2js, $ionicModal, $ionicLoading, $ion
     var xmlDoc = x2js.parseXmlString(response.data);
     var json = x2js.xml2json(xmlDoc);
     $scope.data.actionItems = json.feed.entry;
+    $scope.extractEntryImages();
     $scope.addExtraShareAction();
   }, function (response) {
     // Action feed failed to load.
@@ -26,6 +27,15 @@ var ActionCtrl = function ($scope, $http, x2js, $ionicModal, $ionicLoading, $ion
     // We add an extra action into those we get from RSS, that encourages the users
     // to tell their contacts about the app.
     $scope.data.actionItems.splice(0, 0, acmSharing.shareAppAsAction());
+  };
+
+  $scope.extractEntryImages = function () {
+    $scope.data.actionItems.forEach(function(action) {
+      if (action.link.forEach) {
+        var link = action.link.find(function(link) { return link._rel == 'enclosure' });
+        action.image = link ? link._href : null;
+      }
+    });
   };
 
   $scope.showActionModal = function (actionItem) {


### PR DESCRIPTION
https://github.com/EFForg/action-center-platform/pull/298 updates to the atom feed include removing the `<image>` tag from entries (to fix https://github.com/EFForg/action-center-platform/issues/297). The banner image is now given by the `<link rel="enclosure" ...` element. This branch updates the mobile app accordingly.

When the act.eff.org changes are deployed, users will see [action-default.png](https://github.com/EFForg/actioncenter-mobile/blob/develop/www/img/action-default.png) until the mobile app is released/updated.